### PR TITLE
Add functionality to merge existing keys into output files

### DIFF
--- a/json/export/extractor.py
+++ b/json/export/extractor.py
@@ -26,9 +26,17 @@ for key in list(source_data.keys()):
     if key in target_data:
         del source_data[key]
 
-# 將處理後的內容寫入完成檔案
+# 如果现有数据中存在一个在源数据中不存在的键，它将被添加到源数据中
 output_file_path = './json/source/extensions/' + os.path.basename(source_file_path)
+if os.path.exists(output_file_path):
+    with open(output_file_path, 'r', encoding='utf-8') as f:
+        existing_data = json.load(f)
+    for key, value in existing_data.items():
+        if key not in source_data:
+            source_data[key] = value
+
+# 將處理後的內容寫入完成檔案
 with open(output_file_path, 'w', encoding='utf-8') as f:
-    json.dump(source_data, f, ensure_ascii=False, indent=4)
+    json.dump(source_data, f, ensure_ascii=False, indent=4, sort_keys=True)
 
 print(f'處理完成，結果已儲存至 {output_file_path}')


### PR DESCRIPTION
This pull request adds a new feature to the script that handles JSON files. The changes include checking if the output file already exists before writing the processed data. If the output file exists, the script reads the existing data and merges any keys that are not present in the source data. This ensures that the final output file contains both the newly processed data and any previously existing data that does not conflict with the new data.

Also, added `sort_keys=True` when outputting files. Sorted keys make it easier to compare different versions of the file or to identify differences between files.

Example:
![image](https://user-images.githubusercontent.com/1701388/226576285-e5e47aee-710b-49f2-aee8-c1369ca9166a.png)
